### PR TITLE
VAL-7829: Added changes for terraform ops

### DIFF
--- a/controller-svc-account.tf
+++ b/controller-svc-account.tf
@@ -13,7 +13,8 @@ resource "google_project_iam_member" "controller_role" {
     "roles/iam.serviceAccountUser",
     "roles/pubsub.admin",
     "roles/logging.admin",
-    "roles/storage.admin"
+    "roles/storage.admin",
+    "roles/iam.serviceAccountTokenCreator"
   ])
   project = var.project_id
   role    = each.key

--- a/realtime-inventory.tf
+++ b/realtime-inventory.tf
@@ -9,6 +9,9 @@ resource "google_pubsub_subscription" "invsub" {
   topic = google_pubsub_topic.invtopic[count.index].name
   push_config {
     push_endpoint = var.valtix_webhook
+    oidc_token {
+      service_account_email = google_service_account.controller_account.email
+    }
   }
 }
 


### PR DESCRIPTION
Problem
Webhook server does not authenticate GCP PubSub Events

Solution
When new GCP account are created add "enable authentication" permission